### PR TITLE
Fix test password_does_not_match and improve CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,29 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:
-
+    name: 🧑‍🔬 Test project
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - name: ⬇️ Checkout project
+        uses: actions/checkout@v2
 
-      - name: Start all the environment
+      - name: 🏁 Start all the environment
         run: docker-compose up -d
 
-      - name: Wait for the environment to get up
+      - name: ⏱️ Wait for the environment to get up
         run: |
           while ! make ping-mysql &>/dev/null; do
               echo "Waiting for database connection..."
               sleep 2
           done
 
-      - name: Run the tests
+      - name: 🧪 Run the tests
         run: make test

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ allprojects {
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
     implementation 'org.elasticsearch.client:elasticsearch-rest-client:6.8.5'
     implementation 'org.elasticsearch.client:elasticsearch-rest-high-level-client:6.8.4'
-    runtime 'mysql:mysql-connector-java:8.0.18'
+    runtimeOnly 'mysql:mysql-connector-java:8.0.18'
 
     // Test
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
@@ -136,8 +136,8 @@ sourceSets {
 apply plugin: 'application'
 
 bootJar {
-  baseName = 'java-ddd-skeleton'
-  version = '0.0.1'
+  archiveBaseName = 'java-ddd-skeleton'
+  archiveVersion = '0.0.1'
 }
 
 mainClassName = 'tv.codely.apps.Starter'

--- a/src/backoffice/test/tv/codely/backoffice/auth/application/authenticate/AuthenticateUserCommandHandlerShould.java
+++ b/src/backoffice/test/tv/codely/backoffice/auth/application/authenticate/AuthenticateUserCommandHandlerShould.java
@@ -43,7 +43,7 @@ final class AuthenticateUserCommandHandlerShould extends AuthModuleUnitTestCase 
     }
 
     @Test
-    void throw_an_exception_when_the_password_does_not_math() {
+    void throw_an_exception_when_the_password_does_not_match() {
         assertThrows(InvalidAuthCredentials.class, () -> {
             AuthenticateUserCommand command  = AuthenticateUserCommandMother.random();
             AuthUser                authUser = AuthUserMother.withUsernameAndPassword(command.username(),

--- a/src/backoffice/test/tv/codely/backoffice/auth/application/authenticate/AuthenticateUserCommandHandlerShould.java
+++ b/src/backoffice/test/tv/codely/backoffice/auth/application/authenticate/AuthenticateUserCommandHandlerShould.java
@@ -46,7 +46,8 @@ final class AuthenticateUserCommandHandlerShould extends AuthModuleUnitTestCase 
     void throw_an_exception_when_the_password_does_not_math() {
         assertThrows(InvalidAuthCredentials.class, () -> {
             AuthenticateUserCommand command  = AuthenticateUserCommandMother.random();
-            AuthUser                authUser = AuthUserMother.withUsername(command.username());
+            AuthUser                authUser = AuthUserMother.withUsernameAndPassword(command.username(),
+                                                                                      command.password().concat("👎"));
 
             shouldSearch(authUser.username(), authUser);
 

--- a/src/backoffice/test/tv/codely/backoffice/auth/domain/AuthUserMother.java
+++ b/src/backoffice/test/tv/codely/backoffice/auth/domain/AuthUserMother.java
@@ -15,7 +15,7 @@ public final class AuthUserMother {
         return create(AuthUsernameMother.create(command.username()), AuthPasswordMother.create(command.password()));
     }
 
-    public static AuthUser withUsername(String username) {
-        return create(AuthUsernameMother.create(username), AuthPasswordMother.random());
+    public static AuthUser withUsernameAndPassword(String username, String password) {
+        return create(AuthUsernameMother.create(username), AuthPasswordMother.create(password));
     }
 }


### PR DESCRIPTION
Sometimes the randomly generated password for the `AuthenticateUserCommand` matches the randomly generated `AuthUser` password. Because of this, the `throw_an_exception_when_the_password_does_not_match` test fails.

This issue has been fixed and the GH Actions CI workflow has also been updated.