### PR TITLE
Error RequestMappingHandlerMapping' that could not be found.

### DIFF
--- a/apps/main/tv/codely/apps/mooc/backend/config/MoocBackendServerConfiguration.java
+++ b/apps/main/tv/codely/apps/mooc/backend/config/MoocBackendServerConfiguration.java
@@ -5,8 +5,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 import tv.codely.shared.infrastructure.spring.ApiExceptionMiddleware;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 
 @Configuration
+@ConditionalOnWebApplication
 public class MoocBackendServerConfiguration {
     private final RequestMappingHandlerMapping mapping;
 


### PR DESCRIPTION
Parameter 0 of constructor in tv.codely.apps.mooc.backend.config.MoocBackendServerConfiguration required a bean of type 'org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping' that could not be found.

El error se da cuando se lanza un comando que no requiere el servidor web y hace que este bean igual se quiera instanciar pero no puede por que le faltan dependencias.